### PR TITLE
Define CVs

### DIFF
--- a/Software/CV.h
+++ b/Software/CV.h
@@ -127,11 +127,11 @@ uint8_t CV_ARRAY_DEFAULT [CV_ARRAY_SIZE] = {
    0b00000000,         //CV_102  -
    0b00000000,         //CV_103  -
    0b00000000,         //CV_104  -
-   0b00000000,         //CV_105  -
-   0b00000000,         //CV_106  -
-   0b00000000,         //CV_107  -
-   0b00000000,         //CV_108  -
-   0b00000000,         //CV_109  -
+   0b00000000,         //CV_105  - user data
+   0b00000000,         //CV_106  - user data
+   0b00000001,         //CV_107  - MSB Manufacturer ID for DIY https://www.decoderdb.com/database/decoderdb-list
+   0b00001011,         //CV_108  - LSB Manufacturer ID
+   0b00000000,         //CV_109  - decoder id
    0b00000000,         //CV_110  -
    0b00000000,         //CV_111  -
 ///// PWM - Configuration //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Software/CV.h
+++ b/Software/CV.h
@@ -131,7 +131,7 @@ uint8_t CV_ARRAY_DEFAULT [CV_ARRAY_SIZE] = {
    0b00000000,         //CV_106  - user data
    0b00000001,         //CV_107  - MSB Manufacturer ID for DIY https://www.decoderdb.com/database/decoderdb-list
    0b00001011,         //CV_108  - LSB Manufacturer ID
-   0b00000000,         //CV_109  - decoder id
+   DECODER_ID,         //CV_109  - Decoder ID defined by board .h file (e.g. RP2040-Decoder-board-USB.h)
    0b00000000,         //CV_110  -
    0b00000000,         //CV_111  -
 ///// PWM - Configuration //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Software/RP2040-Decoder-board-Legacy.h
+++ b/Software/RP2040-Decoder-board-Legacy.h
@@ -20,6 +20,9 @@
 // For board detection
 #define RP2040_DECODER
 
+// Decoder ID (CV_109)
+#define DECODER_ID 1
+
 // In case the xosc takes longer to stabilize than usual
 #ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
 #define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/Software/RP2040-Decoder-board-USB.h
+++ b/Software/RP2040-Decoder-board-USB.h
@@ -19,6 +19,9 @@
 // For board detection
 #define RP2040_DECODER
 
+// Decoder ID (CV_109)
+#define DECODER_ID 2
+
 // In case the xosc takes longer to stabilize than usual
 #ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
 #define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64


### PR DESCRIPTION
Define CVs for decoder ID, user data and DIY manufacturer ID from DecoderDB:
https://www.decoderdb.de/datenbank/decoderdb-liste